### PR TITLE
Add line matching support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,6 +57,6 @@ Example output::
     Subject:     break interest resource
     Link:        https://example.com/D1000
     Files Modified:
-       - webapp/resources/interests_resource.py
+       - webapp/resources/interests_resource.py:232
     Lines Added:
        - "if self.options['from_navigate'] == "true":"

--- a/git_stacktrace/api.py
+++ b/git_stacktrace/api.py
@@ -37,7 +37,10 @@ def _lookup_files(commit_files, git_files, traceback, results):
                 if git_file in file_list:
                     git_file = file_list[file_list.index(git_file)]
                     line.git_filename = git_file.filename
-                    results.get_result(commit).add_file(git_file)
+                    line_number = None
+                    if git.line_match(commit, line):
+                        line_number = line.line_number
+                    results.get_result(commit).add_file(git_file, line_number)
             if line.git_filename is None:
                 line.git_filename = _longest_filename(matches)
 
@@ -80,8 +83,8 @@ def lookup_stacktrace(traceback, git_range, fast):
                 # If this fails, move on
                 continue
         for commit, line_removed in commits:
-            if line_removed:
+            if line_removed is True:
                 results.get_result(commit).lines_removed.add(line.code)
-            else:
+            if line_removed is False:
                 results.get_result(commit).lines_added.add(line.code)
     return results

--- a/git_stacktrace/result.py
+++ b/git_stacktrace/result.py
@@ -11,18 +11,24 @@ class Result(object):
         self.files_added = set()
         self.lines_added = set()
         self.lines_removed = set()
+        self._line_numbers_matched = 0
 
     @property
     def commit(self):
         return self._commit
 
-    def add_file(self, git_file):
-        if git_file.state in [git.GitFile.ADDED, git.GitFile.COPY_EDIT]:
-            self.files_added.add(git_file.filename)
-        elif git_file.state in [git.GitFile.DELETED]:
-            self.files_deleted.add(git_file.filename)
+    def add_file(self, git_file, line_number=None):
+        if line_number:
+            self._line_numbers_matched += 1
+            filename = git_file.filename + ":" + str(line_number)
         else:
-            self.files_modified.add(git_file.filename)
+            filename = git_file.filename
+        if git_file.state in [git.GitFile.ADDED, git.GitFile.COPY_EDIT]:
+            self.files_added.add(filename)
+        elif git_file.state in [git.GitFile.DELETED]:
+            self.files_deleted.add(filename)
+        else:
+            self.files_modified.add(filename)
 
     def __hash__(self):
         return hash(self.commit)
@@ -66,7 +72,7 @@ class Result(object):
 
     def rank(self):
         return (len(self.files_modified) + len(self.files_deleted)*2 + len(self.files_added)*3 +
-                len(self.lines_added)*3 + len(self.lines_removed)*2)
+                len(self.lines_added)*3 + len(self.lines_removed)*2 + self._line_numbers_matched*4)
 
 
 class Results(object):

--- a/git_stacktrace/tests/test_api.py
+++ b/git_stacktrace/tests/test_api.py
@@ -35,17 +35,36 @@ class TestApi(base.TestCase):
     @mock.patch('git_stacktrace.git.pickaxe')
     @mock.patch('git_stacktrace.git.files_touched')
     @mock.patch('git_stacktrace.git.files')
-    def test_lookup_stacktrace(self, mock_files, mock_files_touched, mock_pickaxe):
+    @mock.patch('git_stacktrace.git.line_match')
+    def test_lookup_stacktrace(self, mock_line_match, mock_files, mock_files_touched, mock_pickaxe):
+        mock_files_touched.return_value = True
+        mock_line_match.return_value = False
         traceback = self.get_traceback()
         self.setup_mocks(mock_files, mock_files_touched)
-        api.lookup_stacktrace(traceback, "hash1..hash3", fast=False)
+        self.assertEqual(0, api.lookup_stacktrace(traceback, "hash1..hash3", fast=False).
+                         get_sorted_results()[0]._line_numbers_matched)
         self.assertEqual(3, mock_pickaxe.call_count)
 
     @mock.patch('git_stacktrace.git.pickaxe')
     @mock.patch('git_stacktrace.git.files_touched')
     @mock.patch('git_stacktrace.git.files')
-    def test_lookup_stacktrace_fast(self, mock_files, mock_files_touched, mock_pickaxe):
+    @mock.patch('git_stacktrace.git.line_match')
+    def test_lookup_stacktrace_fast(self, mock_line_match, mock_files, mock_files_touched, mock_pickaxe):
+        mock_files_touched.return_value = True
         traceback = self.get_traceback()
         self.setup_mocks(mock_files, mock_files_touched)
         api.lookup_stacktrace(traceback, "hash1..hash3", fast=True)
         self.assertEqual(1, mock_pickaxe.call_count)
+
+    @mock.patch('git_stacktrace.git.pickaxe')
+    @mock.patch('git_stacktrace.git.files_touched')
+    @mock.patch('git_stacktrace.git.files')
+    @mock.patch('git_stacktrace.git.line_match')
+    def test_lookup_stacktrace_line_match(self, mock_line_match, mock_files, mock_files_touched, mock_pickaxe):
+        mock_files_touched.return_value = True
+        mock_line_match.return_value = True
+        traceback = self.get_traceback()
+        self.setup_mocks(mock_files, mock_files_touched)
+        self.assertEqual(1, api.lookup_stacktrace(traceback, "hash1..hash3", fast=False).
+                         get_sorted_results()[0]._line_numbers_matched)
+        self.assertEqual(3, mock_pickaxe.call_count)

--- a/git_stacktrace/tests/test_result.py
+++ b/git_stacktrace/tests/test_result.py
@@ -17,10 +17,10 @@ class TestResult(base.TestCase):
 
     def test_files(self):
         commit1 = result.Result(self.commit_hash)
-        expected_files_modified = set(['file1'])
+        expected_files_modified = set(['file1:10', 'file1'])
         expected_files_added = set(['file2', 'file3'])
         expected_files_deleted = set(['file4'])
-        commit1.add_file(git.GitFile('file1', 'M'))
+        commit1.add_file(git.GitFile('file1', 'M'), line_number=10)
         commit1.add_file(git.GitFile('file1', 'M'))
         commit1.add_file(git.GitFile('file2', 'A'))
         commit1.add_file(git.GitFile('file3', 'C'))
@@ -56,9 +56,9 @@ class TestResult(base.TestCase):
         commit1.lines_removed.add('True')
         expected = ("custom\nLink:        url\nFiles Added:\n    - file2\nFiles Modified:\n    - "
                     "file1\nLines Added:\n    - \"pass\"\nLines Removed:\n    - \"True\"\n")
-        commit1.add_file(git.GitFile('file3', 'D'))
+        commit1.add_file(git.GitFile('file3', 'D'), line_number=11)
         expected = ("custom\nLink:        url\nFiles Added:\n    - file2\nFiles Modified:\n    - "
-                    "file1\nFiles Deleted:\n    - file3\nLines Added:\n    - "
+                    "file1\nFiles Deleted:\n    - file3:11\nLines Added:\n    - "
                     "\"pass\"\nLines Removed:\n    - \"True\"\n")
         self.assertEqual(expected, str(commit1))
 
@@ -85,19 +85,21 @@ class TestResult(base.TestCase):
         self.assertEqual(4, commit1.rank())
         commit1.lines_added.add('pass')
         self.assertEqual(7, commit1.rank())
+        commit1.add_file(git.GitFile('file3', 'M'), line_number=12)
+        self.assertEqual(12, commit1.rank())
 
     @mock.patch('git_stacktrace.git.get_commit_info')
     def test_dict(self, mocked_git_info):
         mocked_git_info.return_value = "custom", "full", "url"
         commit1 = result.Result(self.commit_hash)
         commit1.add_file(git.GitFile('file1', 'M'))
-        commit1.add_file(git.GitFile('file2', 'A'))
+        commit1.add_file(git.GitFile('file2', 'A'), line_number=12)
         commit1.add_file(git.GitFile('file3', 'D'))
         commit1.lines_removed.add('True')
         commit1.lines_added.add('pass')
         expected = {
                     'commit': 'hash1',
-                    'files_added': ['file2'],
+                    'files_added': ['file2:12'],
                     'files_modified': ['file1'],
                     'files_deleted': ['file3'],
                     'full': 'full',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+whatthepatch


### PR DESCRIPTION
Instead of simply matching file names, check to see if the line number
in the stacktrace was modified in a given commit.

This should add more signal to java stacktraces since they don't include
code snippets.