### PR TITLE
Fix files_touched to support longer hashes

### DIFF
--- a/git_stacktrace/git.py
+++ b/git_stacktrace/git.py
@@ -84,8 +84,9 @@ def files_touched(git_range):
         if SHA1_REGEX.match(line):
             commit = line
         elif line.strip():
-            filename = line.split('\t')[-1]
-            state = line[37]
+            split_line = line.split('\t')
+            filename = split_line[-1]
+            state = split_line[0].split(' ')[-1][0]
             commits[commit].append(GitFile(filename, state))
     return commits
 

--- a/git_stacktrace/tests/test_git.py
+++ b/git_stacktrace/tests/test_git.py
@@ -51,6 +51,7 @@ class TestGit(base.TestCase):
             ":100644 100644 abcd123... 1234567... C68	file1	file2",
             ":100644 100644 abcd123... 1234567... R86	file1	file3",
             ":000000 100644 0000000... 1234567... A	file4 space/log",
+            ":100644 100644 f9731ae1d4... 6dc2860... M       test/file"
             ":100644 000000 1234567... 0000000... D	file5"])
         expected = {"1ca8dd2b178ef8f308849bac2b0eaecaf91abc70": ["file0", "file2", "file3", "file4 space/log", "file5"]}
         self.assertEqual(expected, git.files_touched("A..B"))


### PR DESCRIPTION
Sometimes 'git log --pretty="%H" --raw' uses hashes that of different
sizes so we can't assume the state is at position 37.