### PR TITLE
Handle case where python traceback is missing lines of code

### DIFF
--- a/git_stacktrace/cmd.py
+++ b/git_stacktrace/cmd.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 
 import argparse
+import logging
 import os
 import select
 import sys
@@ -23,7 +24,12 @@ def main():
                         'specify which branch to run since on. Runs on current branch by default')
     parser.add_argument('--version', action="version",
                         version='%s version %s' % (os.path.split(sys.argv[0])[-1], git_stacktrace.__version__))
+    parser.add_argument('-d', '--debug', action='store_true', help='Enable debug logging')
     args = parser.parse_args()
+
+    logging.basicConfig(format='%(name)s:%(funcName)s:%(lineno)s: %(message)s')
+    if args.debug:
+        logging.getLogger().setLevel(logging.DEBUG)
 
     if args.since:
         git_range = api.convert_since(args.since, branch=args.branch)

--- a/git_stacktrace/tests/examples/python7.trace
+++ b/git_stacktrace/tests/examples/python7.trace
@@ -1,0 +1,28 @@
+ValueError: invalid literal for int() with base 10: 'None'
+  File "flask/app.py", line 1982, in wsgi_app
+    response = self.full_dispatch_request()
+  File "flask/app.py", line 1614, in full_dispatch_request
+    rv = self.handle_user_exception(e)
+  File "flask_cors/extension.py", line 161, in wrapped_function
+    return cors_after_request(app.make_response(f(*args, **kwargs)))
+  File "flask/app.py", line 1517, in handle_user_exception
+    reraise(exc_type, exc_value, tb)
+  File "flask/_compat.py", line 33, in reraise
+    raise value
+  File "flask/app.py", line 1612, in full_dispatch_request
+    rv = self.dispatch_request()
+  File "flask/app.py", line 1598, in dispatch_request
+    return self.view_functions[rule.endpoint](**req.view_args)
+  File "<decorator-gen-39>", line 2, in ci
+  File "geetest_client.py", line 209, in captcha_counter_decorator
+    return func(*args, **kwargs)
+  File "company.py", line 305, in ci
+    company = get_company_info(company_id)
+  File "company.py", line 129, in get_company_info
+    return get_company_info_from_es(company_id) or get_company_info_from_element(company_id)
+  File "company.py", line 144, in get_company_info_from_es
+    annuals = choose_and_prettify_annual(company_id, result.get('extra', {}).get('类型', ''))
+  File "company.py", line 174, in choose_and_prettify_annual
+    result = prettify(annuals, is_llc=is_llc, show_all=show_all)
+  File "prettify/annual.py", line 45, in prettify
+    year = int(annual.get('year') or 0)

--- a/git_stacktrace/tests/test_parse_trace.py
+++ b/git_stacktrace/tests/test_parse_trace.py
@@ -100,4 +100,7 @@ class TestParseTrace(base.TestCase):
     def test_parse_trace(self):
         for filename in glob.glob('git_stacktrace/tests/examples/*.trace'):
             with open(filename) as f:
-                parse_trace.parse_trace(f.readlines())
+                try:
+                    parse_trace.parse_trace(f.readlines())
+                except Exception:
+                    self.fail("Failed to parse '%s'" % filename)


### PR DESCRIPTION
Python traceback's don't always include a line of code for each line in
the traceback. Update extract_traceback to work in this case and add a
test case.

Also add debug mode logging

Fixes issue #10 