### PR TITLE
Handle python stacktaces that end without any code

### DIFF
--- a/git_stacktrace/parse_trace.py
+++ b/git_stacktrace/parse_trace.py
@@ -113,7 +113,7 @@ class PythonTraceback(Traceback):
                 f = words[0].split('"')[1].strip()
                 line_number = int(words[1].split(' ')[1])
                 function_name = ' '.join(words[2].split(' ')[1:]).strip()
-                if lines[i+1].startswith(self.FILE_LINE_START):
+                if len(lines) == i+1 or lines[i+1].startswith(self.FILE_LINE_START):
                     # Not all lines have code in the traceback
                     code = None
                 else:

--- a/git_stacktrace/tests/examples/python8.trace
+++ b/git_stacktrace/tests/examples/python8.trace
@@ -1,0 +1,5 @@
+Traceback (most recent call last):
+  File "foo.py", line 2, in <module>
+    x()
+  File "<string>", line 1, in <lambda>
+TypeError: int() argument must be a string or a number, not 'NoneType'


### PR DESCRIPTION
Previously the stacktrace generated by the following would fail to
parse.
```
  x = eval('lambda: int(None)')
  x()
```
Fix and add a test case