### PR TITLE
Improve the python API for results

### DIFF
--- a/git_stacktrace/api.py
+++ b/git_stacktrace/api.py
@@ -10,8 +10,9 @@ Example usage::
     git_range = api.convert_since('1.day')
     results = api.lookup_stacktrace(traceback, git_range)
     for r in results.get_sorted_results():
-        print ""
-        print r
+        if "Smith" in r.author
+            print("")
+            print(r)
 """
 
 import logging

--- a/git_stacktrace/api.py
+++ b/git_stacktrace/api.py
@@ -8,7 +8,7 @@ Example usage::
 
     traceback = api.parse_trace(traceback_string)
     git_range = api.convert_since('1.day')
-    results = api.lookup_stacktrace(traceback, git_range, fast=False)
+    results = api.lookup_stacktrace(traceback, git_range)
     for r in results.get_sorted_results():
         print ""
         print r
@@ -74,7 +74,7 @@ def valid_range(git_range):
     return git.valid_range(git_range)
 
 
-def lookup_stacktrace(traceback, git_range, fast):
+def lookup_stacktrace(traceback, git_range, fast=False):
     """Lookup to see what commits in git_range could have caused the stacktrace.
 
     Pass in a stacktrace object and returns a results object.

--- a/git_stacktrace/tests/test_result.py
+++ b/git_stacktrace/tests/test_result.py
@@ -5,6 +5,9 @@ from git_stacktrace.tests import base
 from git_stacktrace import git
 from git_stacktrace import result
 
+fake_commit_info = git.CommitInfo(summary='summary', subject='subject', body='body', url='url',
+                                  author='author', date=None)
+
 
 class TestResult(base.TestCase):
     commit_hash = 'hash1'
@@ -43,36 +46,36 @@ class TestResult(base.TestCase):
 
     @mock.patch('git_stacktrace.git.get_commit_info')
     def test_str(self, mocked_git_info):
-        mocked_git_info.return_value = "custom", "full", "url"
+        mocked_git_info.return_value = fake_commit_info
         commit1 = result.Result(self.commit_hash)
         commit1.add_file(git.GitFile('file1', 'M'))
-        expected = "custom\nLink:        url\nFiles Modified:\n    - file1\n"
+        expected = "summary\nLink:        url\nFiles Modified:\n    - file1\n"
         commit1.add_file(git.GitFile('file2', 'A'))
-        expected = "custom\nLink:        url\nFiles Added:\n    - file2\nFiles Modified:\n    - file1\n"
+        expected = "summary\nLink:        url\nFiles Added:\n    - file2\nFiles Modified:\n    - file1\n"
         self.assertEqual(expected, str(commit1))
         commit1.lines_added.add('pass')
-        expected = ("custom\nLink:        url\nFiles Added:\n    - file2\nFiles Modified:\n    - "
+        expected = ("summary\nLink:        url\nFiles Added:\n    - file2\nFiles Modified:\n    - "
                     "file1\nLines Added:\n    - \"pass\"\n")
         commit1.lines_removed.add('True')
-        expected = ("custom\nLink:        url\nFiles Added:\n    - file2\nFiles Modified:\n    - "
+        expected = ("summary\nLink:        url\nFiles Added:\n    - file2\nFiles Modified:\n    - "
                     "file1\nLines Added:\n    - \"pass\"\nLines Removed:\n    - \"True\"\n")
         commit1.add_file(git.GitFile('file3', 'D'), line_number=11)
-        expected = ("custom\nLink:        url\nFiles Added:\n    - file2\nFiles Modified:\n    - "
+        expected = ("summary\nLink:        url\nFiles Added:\n    - file2\nFiles Modified:\n    - "
                     "file1\nFiles Deleted:\n    - file3:11\nLines Added:\n    - "
                     "\"pass\"\nLines Removed:\n    - \"True\"\n")
         self.assertEqual(expected, str(commit1))
 
     @mock.patch('git_stacktrace.git.get_commit_info')
     def test_str_no_url(self, mocked_git_info):
-        mocked_git_info.return_value = "custom", "full", None
+        mocked_git_info.return_value = git.CommitInfo('summary', 'subject', 'body', None, 'author', None)
         commit1 = result.Result(self.commit_hash)
         commit1.add_file(git.GitFile('file1', 'M'))
-        expected = "custom\nFiles Modified:\n    - file1\n"
+        expected = "summary\nFiles Modified:\n    - file1\n"
         self.assertEqual(expected, str(commit1))
         commit1.lines_added.add('pass')
-        expected = "custom\nFiles Modified:\n    - file1\nLines Added:\n    - \"pass\"\n"
+        expected = "summary\nFiles Modified:\n    - file1\nLines Added:\n    - \"pass\"\n"
         commit1.lines_removed.add('True')
-        expected = ("custom\nFiles Modified:\n    - file1\nLines Added:\n    - \"pass\"\nLines "
+        expected = ("summary\nFiles Modified:\n    - file1\nLines Added:\n    - \"pass\"\nLines "
                     "Removed:\n    - \"True\"\n")
         self.assertEqual(expected, str(commit1))
 
@@ -90,7 +93,7 @@ class TestResult(base.TestCase):
 
     @mock.patch('git_stacktrace.git.get_commit_info')
     def test_dict(self, mocked_git_info):
-        mocked_git_info.return_value = "custom", "full", "url"
+        mocked_git_info.return_value = fake_commit_info
         commit1 = result.Result(self.commit_hash)
         commit1.add_file(git.GitFile('file1', 'M'))
         commit1.add_file(git.GitFile('file2', 'A'), line_number=12)
@@ -102,12 +105,27 @@ class TestResult(base.TestCase):
                     'files_added': ['file2:12'],
                     'files_modified': ['file1'],
                     'files_deleted': ['file3'],
-                    'full': 'full',
+                    'body': 'body',
+                    'date': None,
+                    'author': 'author',
+                    'subject': 'subject',
                     'lines_added': ['pass'],
                     'lines_removed': ['True'],
-                    'custom': 'custom',
+                    'summary': 'summary',
                     'url': 'url'}
         self.assertEqual(expected, dict(commit1))
+
+    @mock.patch('git_stacktrace.git.get_commit_info')
+    def test_git_info(self, mocked_git_info):
+        mocked_git_info.return_value = fake_commit_info
+        commit1 = result.Result(self.commit_hash)
+        self.assertEqual(commit1.summary, "summary")
+        self.assertEqual(commit1.subject, "subject")
+        self.assertEqual(commit1.body, "body")
+        self.assertEqual(commit1.url, "url")
+        self.assertEqual(commit1.author, "author")
+        self.assertEqual(commit1.date, None)
+        self.assertEqual(mocked_git_info.call_count, 1)
 
 
 class TestResults(base.TestCase):
@@ -137,7 +155,7 @@ class TestResults(base.TestCase):
 
     @mock.patch('git_stacktrace.git.get_commit_info')
     def test_get_sorted_results_by_dict(self, mocked_git_info):
-        mocked_git_info.return_value = "custom", "full", "url"
+        mocked_git_info.return_value = fake_commit_info
         results = result.Results()
         commit2 = results.get_result('hash2')
         commit1 = results.get_result('hash1')

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,6 @@
 testtools
 flake8
-testrepository
+pytest
 python-subunit
 fixtures
 mock

--- a/tox.ini
+++ b/tox.ini
@@ -1,21 +1,21 @@
 [tox]
 minversion = 2.0
-envlist=py27,py36,pep8,docs
+envlist=py27,py36,flake8,docs
 skipsdist=False
 
 [travis]
 python =
-  2.7: py27, pep8, docs
-  3.5: py35, pep8, docs
-  3.6: py36, pep8, docs
+  2.7: py27, flake8, docs
+  3.5: py35, flake8, docs
+  3.6: py36, flake8, docs
 
 [testenv]
 usedevelop = True
 install_command = pip install -U {opts} {packages}
 deps = -r{toxinidir}/test-requirements.txt
-commands = python setup.py testr --slowest --testr-args='{posargs}'
+commands = pytest {posargs}
 
-[testenv:pep8]
+[testenv:flake8]
 commands = flake8 {posargs}
 
 [testenv:docs]


### PR DESCRIPTION
Improve the python API for results
    
    Previously there was no easy way to access information about a given
    commit from python, it could only be accessed together as a
    pre-formatted string. Make it easier to pragmatically use
    git-stacktrace. For example, you can now easily find the author's email
    and contact them.
    
    New properties of a Result object:
    * summary
    * subject
    * body
    * url
    * author
    * date
    
    Rename some of the fields to make more sense:
    * custom -> summary [Summary of git commit info]
    * full -> body [body of commit message]