### PR TITLE
Add a few missing states

### DIFF
--- a/git_stacktrace/git.py
+++ b/git_stacktrace/git.py
@@ -19,11 +19,14 @@ CommitInfo = collections.namedtuple('CommitInfo', ['summary', 'subject', 'body',
 class GitFile(object):
     """Track filename and if file was added/removed or modified."""
     ADDED = 'A'
+    COPY_EDIT = 'C'
     DELETED = 'D'
     MODIFIED = 'M'
-    COPY_EDIT = 'C'
     RENAME_EDIT = 'R'
-    VALID = frozenset([ADDED, DELETED, MODIFIED, COPY_EDIT, RENAME_EDIT])
+    TYPE = 'T'
+    UNMERGED = 'U'
+    UNKNOWN = 'X'
+    VALID = frozenset([ADDED, DELETED, MODIFIED, COPY_EDIT, RENAME_EDIT, TYPE, UNMERGED, UNKNOWN])
 
     def __init__(self, filename, state=None):
         self.filename = filename

--- a/git_stacktrace/parse_trace.py
+++ b/git_stacktrace/parse_trace.py
@@ -115,12 +115,12 @@ class PythonTraceback(Traceback):
                 f = words[0].split('"')[1].strip()
                 line_number = int(words[1].split(' ')[1])
                 function_name = ' '.join(words[2].split(' ')[1:]).strip()
-                if len(lines) == i+1 or lines[i+1].startswith(self.FILE_LINE_START):
+                if len(lines) == i + 1 or lines[i + 1].startswith(self.FILE_LINE_START):
                     # Not all lines have code in the traceback
                     code = None
                 else:
                     code_line = True
-                    code = str(lines[i+1].strip())
+                    code = str(lines[i + 1].strip())
 
                 try:
                     extracted.append(Line(filename=f, line_number=line_number, function_name=function_name, code=code))

--- a/git_stacktrace/result.py
+++ b/git_stacktrace/result.py
@@ -121,8 +121,8 @@ class Result(object):
         yield 'lines_removed', list(self.lines_removed)
 
     def rank(self):
-        return (len(self.files_modified) + len(self.files_deleted)*2 + len(self.files_added)*3 +
-                len(self.lines_added)*3 + len(self.lines_removed)*2 + self._line_numbers_matched*4)
+        return (len(self.files_modified) + len(self.files_deleted) * 2 + len(self.files_added) * 3 +
+                len(self.lines_added) * 3 + len(self.lines_removed) * 2 + self._line_numbers_matched * 4)
 
     def __eq__(self, other):
         return self.commit == other.commit

--- a/git_stacktrace/tests/test_api.py
+++ b/git_stacktrace/tests/test_api.py
@@ -59,8 +59,8 @@ class TestApi(base.TestCase):
         traceback = self.get_traceback(java=True)
         mock_files.return_value = ['devdaily/src/main/java/com/devdaily/tests/ExceptionTest.java']
         mock_files_touched.return_value = {
-                'hash2':
-                [git.GitFile('devdaily/src/main/java/com/devdaily/tests/ExceptionTest.java', 'M')]}
+            'hash2':
+            [git.GitFile('devdaily/src/main/java/com/devdaily/tests/ExceptionTest.java', 'M')]}
         self.assertEqual(2, api.lookup_stacktrace(traceback, "hash1..hash3", fast=False).
                          get_sorted_results()[0]._line_numbers_matched)
         self.assertEqual(0, mock_pickaxe.call_count)

--- a/git_stacktrace/tests/test_parse_trace.py
+++ b/git_stacktrace/tests/test_parse_trace.py
@@ -6,11 +6,11 @@ from git_stacktrace import parse_trace
 
 class TestParsePythonStacktrace(base.TestCase):
     trace3_expected = [
-            ('../common/utils/geo_utils.py', 68, 'get_ip_geo', 'return get_geo_db().record_by_addr(ip_address)'),
-            ('/mnt/virtualenv_A/local/lib/python2.7/site-packages/pygeoip/__init__.py', 563,
-                'record_by_addr', 'ipnum = util.ip2long(addr)'),
-            ('/mnt/virtualenv_A/local/lib/python2.7/site-packages/pygeoip/util.py', 36, 'ip2long',
-                'return int(binascii.hexlify(socket.inet_pton(socket.AF_INET6, ip)), 16)')]
+        ('../common/utils/geo_utils.py', 68, 'get_ip_geo', 'return get_geo_db().record_by_addr(ip_address)'),
+        ('/mnt/virtualenv_A/local/lib/python2.7/site-packages/pygeoip/__init__.py', 563,
+            'record_by_addr', 'ipnum = util.ip2long(addr)'),
+        ('/mnt/virtualenv_A/local/lib/python2.7/site-packages/pygeoip/util.py', 36, 'ip2long',
+            'return int(binascii.hexlify(socket.inet_pton(socket.AF_INET6, ip)), 16)')]
 
     def get_trace(self, number=3):
         with open('git_stacktrace/tests/examples/python%d.trace' % number) as f:

--- a/git_stacktrace/tests/test_result.py
+++ b/git_stacktrace/tests/test_result.py
@@ -101,18 +101,18 @@ class TestResult(base.TestCase):
         commit1.lines_removed.add('True')
         commit1.lines_added.add('pass')
         expected = {
-                    'commit': 'hash1',
-                    'files_added': ['file2:12'],
-                    'files_modified': ['file1'],
-                    'files_deleted': ['file3'],
-                    'body': 'body',
-                    'date': None,
-                    'author': 'author',
-                    'subject': 'subject',
-                    'lines_added': ['pass'],
-                    'lines_removed': ['True'],
-                    'summary': 'summary',
-                    'url': 'url'}
+            'commit': 'hash1',
+            'files_added': ['file2:12'],
+            'files_modified': ['file1'],
+            'files_deleted': ['file3'],
+            'body': 'body',
+            'date': None,
+            'author': 'author',
+            'subject': 'subject',
+            'lines_added': ['pass'],
+            'lines_removed': ['True'],
+            'summary': 'summary',
+            'url': 'url'}
         self.assertEqual(expected, dict(commit1))
 
     @mock.patch('git_stacktrace.git.get_commit_info')
@@ -124,7 +124,7 @@ class TestResult(base.TestCase):
         self.assertEqual(commit1.body, "body")
         self.assertEqual(commit1.url, "url")
         self.assertEqual(commit1.author, "author")
-        self.assertEqual(commit1.date, None)
+        self.assertIsNone(commit1.date, None)
         self.assertEqual(mocked_git_info.call_count, 1)
 
 


### PR DESCRIPTION
According to man git-diff there were a few missing states, and hitting
one would cause an exception. The strict status matching is there to
make help make sure we are parsing things correctly.