### PR TITLE
Use raw string to avoid a deprecated regex escape

### DIFF
--- a/git_stacktrace/parse_trace.py
+++ b/git_stacktrace/parse_trace.py
@@ -175,7 +175,7 @@ class JavaTraceback(Traceback):
             unknown_source = True
 
         # split on ' ', '(', ')', ':'
-        tokens = re.split(" |\(|\)|:", line_string.strip())
+        tokens = re.split(r" |\(|\)|:", line_string.strip())
 
         if tokens[0] != "at" or len(tokens) != 5:
             raise ParseException("Invalid Java Exception")


### PR DESCRIPTION
git_stacktrace/parse_trace.py:178: DeprecationWarning: invalid escape sequence \(
  tokens = re.split(" |\(|\)|:", line_string.strip())