### PR TITLE
Adds Pinterest-flavored JavaScript stacktrace support

### DIFF
--- a/git_stacktrace/tests/examples/javascript1.trace
+++ b/git_stacktrace/tests/examples/javascript1.trace
@@ -1,0 +1,4 @@
+TypeError: Cannot read property 'routes' of undefined
+	#0	at routes (webpack:///mnt/pinboard/webapp/app/www-unauth/Main.js:170:58)
+	#1	at callback (webpack:///mnt/pinboard/webapp/node_modules/react-router/es/match.js:51:0)
+	#2	at callback (webpack:///mnt/pinboard/webapp/node_modules/react-router/es/createTransitionManager.js:79:0)

--- a/git_stacktrace/tests/examples/javascript2.trace
+++ b/git_stacktrace/tests/examples/javascript2.trace
@@ -1,0 +1,3 @@
+	#0	at routes (webpack:///mnt/pinboard/webapp/app/www-unauth/Main.js:170:58)
+	#1	at callback (webpack:///mnt/pinboard/webapp/node_modules/react-router/es/match.js:51:0)
+	#2	at callback (webpack:///mnt/pinboard/webapp/node_modules/react-router/es/createTransitionManager.js:79:0)

--- a/git_stacktrace/tests/examples/javascript3.trace
+++ b/git_stacktrace/tests/examples/javascript3.trace
@@ -1,0 +1,4 @@
+TypeError: Cannot read property 'routes' of undefined
+	#0	at (webpack:///mnt/pinboard/webapp/app/www-unauth/Main.js:170:58)
+	#1	at (webpack:///mnt/pinboard/webapp/node_modules/react-router/es/match.js:51:0)
+	#2	at (webpack:///mnt/pinboard/webapp/node_modules/react-router/es/createTransitionManager.js:79:0)

--- a/git_stacktrace/tests/examples/javascript4.trace
+++ b/git_stacktrace/tests/examples/javascript4.trace
@@ -1,0 +1,4 @@
+TypeError: Cannot read property 'routes' of undefined
+	#0	at routes (https://s.pinimg.com/mobile/js/entryChunk-mobile-16e4a90610ff33cbf2f6.js:12:307245)
+	#1	at callback (webpack:///mnt/pinboard/webapp/node_modules/react-router/es/match.js:51:0)
+	#2	at callback (webpack:///mnt/pinboard/webapp/node_modules/react-router/es/createTransitionManager.js:79:0)

--- a/git_stacktrace/tests/examples/javascript5.trace
+++ b/git_stacktrace/tests/examples/javascript5.trace
@@ -1,0 +1,4 @@
+TypeError: Cannot read property 'routes' of undefined
+	#0	at ha</a.Ja/</< (https://smartlock.google.com/client?clientId=694505692171-31closf3bcmlt59aeulg2j81ej68j6hk.apps.googleusercontent.com:88:389)
+	#1	at callback (webpack:///mnt/pinboard/webapp/node_modules/react-router/es/match.js:51:0)
+	#2	at callback (webpack:///mnt/pinboard/webapp/node_modules/react-router/es/createTransitionManager.js:79:0)

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 2.0
-envlist=py27,py36,flake8,docs
+envlist=py37,flake8,docs
 skipsdist=False
 
 [travis]


### PR DESCRIPTION
This change adds support for parsing the normalized browser stacktrace format that Pinterest logs. There's currently no universally agreed upon stacktrace representation amongst the various JS runtime implementations. Though most seem to converge on something similar to: https://v8.dev/docs/stack-trace-api.

Pinterest logs something similar to v8's representation, with the exception that we prepend `#\d` with the index of the frame for easier reference during live investigations, thus making it incompatible with a more generic v8 parser. This is something we could update in the future to be more in-line with v8's implementation but currently outside the planned scope of related changes.