### PR TITLE
various bug fixes for running git-stacktrace as an API using --server mode

### DIFF
--- a/git_stacktrace/server.py
+++ b/git_stacktrace/server.py
@@ -9,9 +9,17 @@ from git_stacktrace import api
 from six.moves.html_parser import HTMLParser
 from six.moves.urllib_parse import parse_qs
 from string import Template
+from datetime import date, datetime
 
 log = logging.getLogger(__name__)
 dir_path = os.path.dirname(os.path.realpath(__file__))
+
+def json_serial(obj):
+    """JSON serializer for objects not serializable by default json code"""
+
+    if isinstance(obj, (datetime, date)):
+        return obj.isoformat()
+    raise TypeError ("Type %s not serializable" % type(obj))
 
 
 class Args(object):
@@ -107,7 +115,7 @@ class ResultsOutput(object):
             return json.dumps({
                 'errors': None,
                 'commits': self.results.get_sorted_results_by_dict(),
-            })
+            }, default=json_serial)
 
     def results_as_html(self):
         if not self.results:

--- a/git_stacktrace/server.py
+++ b/git_stacktrace/server.py
@@ -14,12 +14,13 @@ from datetime import date, datetime
 log = logging.getLogger(__name__)
 dir_path = os.path.dirname(os.path.realpath(__file__))
 
+
 def json_serial(obj):
     """JSON serializer for objects not serializable by default json code"""
 
     if isinstance(obj, (datetime, date)):
         return obj.isoformat()
-    raise TypeError ("Type %s not serializable" % type(obj))
+    raise TypeError("Type %s not serializable" % type(obj))
 
 
 class Args(object):

--- a/git_stacktrace/server.py
+++ b/git_stacktrace/server.py
@@ -98,7 +98,7 @@ class ResultsOutput(object):
                 'errors': self.messages,
                 'commits': [],
             })
-        elif len(self.results) == 0:
+        elif len(self.results.results) == 0:
             return json.dumps({
                 'errors': 'No matches found',
                 'commits': [],


### PR DESCRIPTION
* `2287fe4` fixes:
```
git_stacktrace.server:do_POST:204: Unable to load trace results as json
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/git_stacktrace/server.py", line 200, in do_POST
    out = ResultsOutput(args).results_as_json()
  File "/usr/local/lib/python3.7/site-packages/git_stacktrace/server.py", line 101, in results_as_json
    elif len(self.results) == 0:
TypeError: object of type 'Results' has no len()
```

* `ac0701c` fixes:

```
git_stacktrace.server:do_POST:207: Unable to load trace results as json
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/git_stacktrace/server.py", line 203, in do_POST
    out = ResultsOutput(args).results_as_json()
  File "/usr/local/lib/python2.7/dist-packages/git_stacktrace/server.py", line 111, in results_as_json
    'commits': self.results.get_sorted_results_by_dict(),
  File "/usr/lib/python2.7/json/__init__.py", line 244, in dumps
    return _default_encoder.encode(obj)
  File "/usr/lib/python2.7/json/encoder.py", line 207, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/lib/python2.7/json/encoder.py", line 270, in iterencode
    return _iterencode(o, 0)
  File "/usr/lib/python2.7/json/encoder.py", line 184, in default
    raise TypeError(repr(o) + " is not JSON serializable")
TypeError: datetime.datetime(2019, 9, 3, 21, 32, 14) is not JSON serializable
```