### PR TITLE
fixes file_match bug in Javascript traceback classes

### DIFF
--- a/git_stacktrace/parse_trace.py
+++ b/git_stacktrace/parse_trace.py
@@ -205,7 +205,7 @@ class JavaTraceback(Traceback):
 
     def file_match(self, trace_filename, git_files):
         # git_filename is substring of trace_filename
-        return [f for f in git_files if f.endswith(trace_filename)]
+        return [f for f in git_files if trace_filename.endswith(f)]
 
 
 class JavaScriptTraceback(Traceback):
@@ -242,7 +242,7 @@ class JavaScriptTraceback(Traceback):
         return ''.join(traceback.format_list(lines))
 
     def file_match(self, trace_filename, git_files):
-        return [f for f in git_files if f.endswith(trace_filename)]
+        return [f for f in git_files if trace_filename.endswith(f)]
 
 
 def parse_trace(traceback_string):

--- a/git_stacktrace/parse_trace.py
+++ b/git_stacktrace/parse_trace.py
@@ -205,7 +205,7 @@ class JavaTraceback(Traceback):
 
     def file_match(self, trace_filename, git_files):
         # git_filename is substring of trace_filename
-        return [f for f in git_files if trace_filename.endswith(f)]
+        return [f for f in git_files if f.endswith(trace_filename)]
 
 
 class JavaScriptTraceback(Traceback):


### PR DESCRIPTION
Updates the Javascript class to find git filename substrings in stacktrace frames which is identical to the Python class. The Java class that the Javascript class was derived from performs this the other way around which, at least for Javascript, results in very rigid file matching.