### PR TITLE
removes advertised Python3 support and other fixups

### DIFF
--- a/git_stacktrace/server.py
+++ b/git_stacktrace/server.py
@@ -205,14 +205,15 @@ class GitStacktraceApplication(object):
     def do_POST(self):
         if self.path == '/':
             try:
-                args = Args.from_json_body(self._request_body())
+                body = self._request_body().decode()
+                args = Args.from_json_body(body)
                 out = ResultsOutput(args).results_as_json()
                 self._set_headers(200, 'application/json')
-                return out
+                return out.encode()
             except Exception as e:
                 log.exception('Unable to load trace results as json')
                 self._set_headers(500, 'application/json')
-                return json.dumps({'error': str(e)})
+                return json.dumps({'error': str(e)}).encode()
         else:
             self._set_headers(404, 'application/json')
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,9 +5,6 @@ license = Apache License (2.0)
 classifier =
     Programming Language :: Python :: 2
     Programming Language :: Python :: 2.7
-    Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.5
-    Programming Language :: Python :: 3.6
     Intended Audience :: Developers
     Operating System :: OS Independent
     License :: OSI Approved :: Apache Software License

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,11 @@
 [tox]
 minversion = 2.0
-envlist=py27,py36,flake8,docs
+envlist=py27,flake8,docs
 skipsdist=False
 
 [travis]
 python =
   2.7: py27, flake8, docs
-  3.5: py35, flake8, docs
-  3.6: py36, flake8, docs
-  3.7: py37, flake8, docs
 
 [testenv]
 usedevelop = True


### PR DESCRIPTION
This is a painful one but ...

The majority of the code seems to have been written with Python3 in-mind but
the API is written for wsgiref under Python2.7. I encountered all sorts of
issues when trying to use Python3 such that this feature was unusable.

We need a hero to port this to Flask or something more modern but sadly I
cannot be that hero today. The easiest way to fix this it is to drop advertised
support for Python3 until the API can be revised with something more Python3
compatible.

