### PR TITLE
[Documentation] Diagram visualization for git-stracktrace's codebase

### DIFF
--- a/.codeboarding/Core_Analysis_Engine.md
+++ b/.codeboarding/Core_Analysis_Engine.md
@@ -1,0 +1,193 @@
+```mermaid
+
+graph LR
+
+    Core_Analysis_Engine["Core Analysis Engine"]
+
+    Git_Interaction["Git Interaction"]
+
+    Trace_Parsing["Trace Parsing"]
+
+    Result_Management["Result Management"]
+
+    Command_Line_Interface_CLI_["Command-Line Interface (CLI)"]
+
+    Web_Interface["Web Interface"]
+
+    Testing_Framework["Testing Framework"]
+
+    Core_Analysis_Engine -- "orchestrates" --> Git_Interaction
+
+    Core_Analysis_Engine -- "populates" --> Result_Management
+
+    Command_Line_Interface_CLI_ -- "invokes" --> Core_Analysis_Engine
+
+    Web_Interface -- "invokes" --> Core_Analysis_Engine
+
+    Result_Management -- "queries" --> Git_Interaction
+
+    Testing_Framework -- "validates" --> Core_Analysis_Engine
+
+    Testing_Framework -- "validates" --> Git_Interaction
+
+    Testing_Framework -- "validates" --> Trace_Parsing
+
+    Testing_Framework -- "validates" --> Result_Management
+
+    Testing_Framework -- "validates" --> Web_Interface
+
+    Command_Line_Interface_CLI_ -- "uses" --> Trace_Parsing
+
+    Web_Interface -- "uses" --> Trace_Parsing
+
+    click Core_Analysis_Engine href "https://github.com/pinterest/git-stacktrace/blob/master/.codeboarding//Core_Analysis_Engine.md" "Details"
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+One paragraph explaining the functionality which is represented by this graph. What the main flow is and what is its purpose.
+
+
+
+### Core Analysis Engine [[Expand]](./Core_Analysis_Engine.md)
+
+The central orchestrator for stacktrace lookup and analysis. It coordinates interactions with the Git Interaction and Traceback Parsing modules and populates the Result Management module. It provides the main entry points for the application's core logic.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pinterest/git-stacktrace/blob/master/git_stacktrace/api.py#L1-L10000" target="_blank" rel="noopener noreferrer">`git_stacktrace.api` (1:10000)</a>
+
+
+
+
+
+### Git Interaction
+
+Responsible for all interactions with the Git version control system. This includes retrieving file information, commit history, performing line-specific lookups (e.g., git blame or git pickaxe), and converting Git-specific time formats.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pinterest/git-stacktrace/blob/master/git_stacktrace/git.py#L1-L10000" target="_blank" rel="noopener noreferrer">`git_stacktrace.git` (1:10000)</a>
+
+
+
+
+
+### Trace Parsing
+
+Specializes in parsing raw stack trace text from various programming languages into a structured, programmatic format. It defines a class hierarchy to handle different trace formats (e.g., Python, Java, JavaScript).
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pinterest/git-stacktrace/blob/master/git_stacktrace/parse_trace.py#L1-L10000" target="_blank" rel="noopener noreferrer">`git_stacktrace.parse_trace` (1:10000)</a>
+
+
+
+
+
+### Result Management
+
+Manages, stores, and provides access to the structured results of the stack trace analysis. It aggregates information, linking parsed stack trace lines with relevant Git commits, files, and authors.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pinterest/git-stacktrace/blob/master/git_stacktrace/result.py#L1-L10000" target="_blank" rel="noopener noreferrer">`git_stacktrace.result` (1:10000)</a>
+
+
+
+
+
+### Command-Line Interface (CLI)
+
+Provides the primary command-line interface for users to interact with the `git-stacktrace` tool. It handles argument parsing, input validation, and orchestrates calls to the Core Analysis Engine based on user commands.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pinterest/git-stacktrace/blob/master/git_stacktrace/cmd.py#L1-L10000" target="_blank" rel="noopener noreferrer">`git_stacktrace.cmd` (1:10000)</a>
+
+
+
+
+
+### Web Interface
+
+Implements a web server (using Flask/FastAPI) to offer a graphical user interface or RESTful API endpoints for the `git-stacktrace` functionality. It handles web requests and renders HTML templates for user interaction.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pinterest/git-stacktrace/blob/master/git_stacktrace/server.py#L1-L10000" target="_blank" rel="noopener noreferrer">`git_stacktrace.server` (1:10000)</a>
+
+- `git_stacktrace.templates` (1:10000)
+
+
+
+
+
+### Testing Framework
+
+Contains a comprehensive suite of unit and integration tests for all other components of the `git-stacktrace` application. These tests ensure the correctness, reliability, and performance of the entire system.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `git_stacktrace.tests` (1:10000)
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Git_Interaction_Module.md
+++ b/.codeboarding/Git_Interaction_Module.md
@@ -1,0 +1,91 @@
+```mermaid
+
+graph LR
+
+    Git_Interaction_Module["Git Interaction Module"]
+
+    API_Facade["API/Facade"]
+
+    Result_Handling["Result Handling"]
+
+    API_Facade -- "uses" --> Git_Interaction_Module
+
+    Result_Handling -- "uses" --> Git_Interaction_Module
+
+    click Git_Interaction_Module href "https://github.com/pinterest/git-stacktrace/blob/master/.codeboarding//Git_Interaction_Module.md" "Details"
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+One paragraph explaining the functionality which is represented by this graph. What the main flow is and what is its purpose.
+
+
+
+### Git Interaction Module [[Expand]](./Git_Interaction_Module.md)
+
+This module provides a comprehensive set of functionalities for interacting with the Git version control system. It handles the execution of Git commands, processes their output, and extracts various types of information such as commit details, file changes, and line-level modifications. It acts as a low-level interface to Git, abstracting away the complexities of command-line execution and output parsing.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pinterest/git-stacktrace/blob/master/git_stacktrace/git.py#L1-L99999" target="_blank" rel="noopener noreferrer">`git_stacktrace.git` (1:99999)</a>
+
+
+
+
+
+### API/Facade
+
+The API/Facade component orchestrates core application logic and directly consumes functionalities from the Git Interaction Module to retrieve Git-related information.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pinterest/git-stacktrace/blob/master/git_stacktrace/api.py#L1-L99999" target="_blank" rel="noopener noreferrer">`git_stacktrace.api` (1:99999)</a>
+
+
+
+
+
+### Result Handling
+
+The Result Handling component utilizes the Git Interaction Module to enrich the parsed stack trace data with Git-specific information, such as commit details and file changes.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pinterest/git-stacktrace/blob/master/git_stacktrace/result.py#L1-L99999" target="_blank" rel="noopener noreferrer">`git_stacktrace.result` (1:99999)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Result_Management_Module.md
+++ b/.codeboarding/Result_Management_Module.md
@@ -1,0 +1,83 @@
+```mermaid
+
+graph LR
+
+    Result_Data_Model["Result Data Model"]
+
+    Results_Collection_Manager["Results Collection Manager"]
+
+    Git_Interaction_Layer["Git Interaction Layer"]
+
+    Results_Collection_Manager -- "Composes" --> Result_Data_Model
+
+    Result_Data_Model -- "Uses" --> Git_Interaction_Layer
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+The `Result Management Module` is central to `git_stacktrace` as it defines and manages the core data structures for representing analysis outcomes. It ensures that the results of Git commit analysis are well-defined, efficiently managed, and easily accessible.
+
+
+
+### Result Data Model
+
+This component defines the structure and behavior of a single Git commit analysis result. It encapsulates various properties of a commit, such as its summary, subject, body, author, date, and URL. A key feature is its lazy-loading mechanism (`_lazy_fetch`), which efficiently retrieves detailed commit information from Git only when it's explicitly accessed. It also defines how individual results are compared (`__lt__`) and formatted for display (`__str__`). This component is fundamental because it provides the atomic unit for representing the analysis output, ensuring data consistency and efficient retrieval of commit details.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pinterest/git-stacktrace/blob/master/git_stacktrace/result.py#L3-L140" target="_blank" rel="noopener noreferrer">`git_stacktrace.result.Result` (3:140)</a>
+
+
+
+
+
+### Results Collection Manager
+
+This component is responsible for managing a collection of `Result` objects. It provides methods to create new `Result` instances (`get_result`) and to retrieve sorted collections of results (`get_sorted_results_by_dict`, `get_sorted_results`). It acts as a container and orchestrator for multiple individual commit results, enabling aggregation and organized access to the analysis output. This component is fundamental as it allows the system to handle multiple analysis results cohesively, providing mechanisms for sorting and retrieval, which is crucial for presenting a comprehensive view of the analysis.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pinterest/git-stacktrace/blob/master/git_stacktrace/result.py#L143-L162" target="_blank" rel="noopener noreferrer">`git_stacktrace.result.Results` (143:162)</a>
+
+
+
+
+
+### Git Interaction Layer
+
+An assumed component responsible for direct Git operations.
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Testing_Suite.md
+++ b/.codeboarding/Testing_Suite.md
@@ -1,0 +1,155 @@
+```mermaid
+
+graph LR
+
+    Test_Base_Framework["Test Base Framework"]
+
+    API_Test_Suite["API Test Suite"]
+
+    Git_Integration_Test_Suite["Git Integration Test Suite"]
+
+    Trace_Parsing_Test_Suite["Trace Parsing Test Suite"]
+
+    Result_Formatting_Test_Suite["Result Formatting Test Suite"]
+
+    Web_Server_Test_Suite["Web Server Test Suite"]
+
+    API_Test_Suite -- "inherits from" --> Test_Base_Framework
+
+    Git_Integration_Test_Suite -- "inherits from" --> Test_Base_Framework
+
+    Trace_Parsing_Test_Suite -- "inherits from" --> Test_Base_Framework
+
+    Result_Formatting_Test_Suite -- "inherits from" --> Test_Base_Framework
+
+    Web_Server_Test_Suite -- "inherits from" --> Test_Base_Framework
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+The `Testing Suite` component is crucial for ensuring the reliability and correctness of the `git_stacktrace` project. It adheres to developer tool patterns by providing a robust and modular testing framework.
+
+
+
+### Test Base Framework
+
+This component provides the foundational base class (`TestCase`) for all unit and integration tests within the project. It encapsulates common setup, teardown, and assertion utilities, promoting code reuse and consistency across all test suites.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pinterest/git-stacktrace/blob/master/git_stacktrace/tests/base.py#L1-L1" target="_blank" rel="noopener noreferrer">`git_stacktrace.tests.base` (1:1)</a>
+
+
+
+
+
+### API Test Suite
+
+This suite contains specific tests designed to validate the functionality and correctness of the `git_stacktrace` API endpoints. It ensures that the API behaves as expected, handling various requests and returning appropriate responses.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pinterest/git-stacktrace/blob/master/git_stacktrace/tests/test_api.py#L1-L1" target="_blank" rel="noopener noreferrer">`git_stacktrace.tests.test_api` (1:1)</a>
+
+
+
+
+
+### Git Integration Test Suite
+
+This component focuses on testing the interactions with Git repositories. It verifies operations such as retrieving file content, commit information, and diffs, ensuring the tool accurately extracts data from Git.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pinterest/git-stacktrace/blob/master/git_stacktrace/tests/test_git.py#L1-L1" target="_blank" rel="noopener noreferrer">`git_stacktrace.tests.test_git` (1:1)</a>
+
+
+
+
+
+### Trace Parsing Test Suite
+
+This suite validates the logic responsible for parsing various types of stack traces (e.g., Python, Java, JavaScript) and accurately extracting relevant information like file paths, line numbers, and function names.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pinterest/git-stacktrace/blob/master/git_stacktrace/tests/test_parse_trace.py#L1-L1" target="_blank" rel="noopener noreferrer">`git_stacktrace.tests.test_parse_trace` (1:1)</a>
+
+
+
+
+
+### Result Formatting Test Suite
+
+This component tests the modules responsible for formatting and presenting the analyzed stack trace results. It ensures the output is user-friendly, consistent, and contains all necessary information.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pinterest/git-stacktrace/blob/master/git_stacktrace/tests/test_result.py#L1-L1" target="_blank" rel="noopener noreferrer">`git_stacktrace.tests.test_result` (1:1)</a>
+
+
+
+
+
+### Web Server Test Suite
+
+This suite contains tests for the web server component, ensuring its stability, correct routing, and proper handling of web requests and responses, particularly for any web-based interface or API.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pinterest/git-stacktrace/blob/master/git_stacktrace/tests/test_server.py#L1-L1" target="_blank" rel="noopener noreferrer">`git_stacktrace.tests.test_server` (1:1)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Traceback_Parsing_Module.md
+++ b/.codeboarding/Traceback_Parsing_Module.md
@@ -1,0 +1,51 @@
+```mermaid
+
+graph LR
+
+    Traceback_Parsing_Module["Traceback Parsing Module"]
+
+    API_Facade -- "processes data via" --> Traceback_Parsing_Module
+
+    Testing -- "validates" --> Traceback_Parsing_Module
+
+    click Traceback_Parsing_Module href "https://github.com/pinterest/git-stacktrace/blob/master/.codeboarding//Traceback_Parsing_Module.md" "Details"
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+This module is fundamental because it acts as the initial data ingestion and transformation layer. Without the ability to accurately parse and structure raw stack traces, the `git-stacktrace` tool would be unable to perform any meaningful analysis, linking, or presentation of the debugging information. It provides the foundational data structure upon which all subsequent operations (like Git interaction and result handling) depend.
+
+
+
+### Traceback Parsing Module [[Expand]](./Traceback_Parsing_Module.md)
+
+This module is responsible for parsing raw stack trace text from various programming languages (e.g., Python, Java, JavaScript) into a structured, programmatic representation. It employs a class hierarchy with a base `Traceback` class and language-specific subclasses (`PythonTraceback`, `JavaTraceback`, `JavaScriptTraceback`) to handle diverse trace formats, extracting crucial information like file paths, line numbers, and function names.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pinterest/git-stacktrace/blob/master/git_stacktrace/parse_trace.py#L1-L1" target="_blank" rel="noopener noreferrer">`git_stacktrace.parse_trace` (1:1)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/User_Interface_UI_Layer.md
+++ b/.codeboarding/User_Interface_UI_Layer.md
@@ -1,0 +1,161 @@
+```mermaid
+
+graph LR
+
+    CLI_Interface["CLI Interface"]
+
+    Web_Server["Web Server"]
+
+    Web_Request_Handler["Web Request Handler"]
+
+    Web_Response_Renderer["Web Response Renderer"]
+
+    Templates["Templates"]
+
+    Core_API["Core API"]
+
+    Trace_Parser["Trace Parser"]
+
+    CLI_Interface -- "Uses" --> Core_API
+
+    CLI_Interface -- "Uses" --> Trace_Parser
+
+    Web_Server -- "Orchestrates" --> Web_Request_Handler
+
+    Web_Server -- "Orchestrates" --> Web_Response_Renderer
+
+    Web_Request_Handler -- "Uses" --> Core_API
+
+    Web_Request_Handler -- "Uses" --> Trace_Parser
+
+    Web_Response_Renderer -- "Uses" --> Templates
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+Abstract Components Overview
+
+
+
+### CLI Interface
+
+This component provides the command-line interface for git-stacktrace. It is responsible for parsing command-line arguments, orchestrating the execution flow by invoking core logic components, and presenting the final analysis results directly to the user via the console. It acts as a direct entry point for users preferring command-line interaction.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pinterest/git-stacktrace/blob/master/git_stacktrace/cmd.py#L1-L1" target="_blank" rel="noopener noreferrer">`git_stacktrace.cmd` (1:1)</a>
+
+
+
+
+
+### Web Server
+
+This component represents the main HTTP server application for the web interface. It is responsible for listening for incoming HTTP requests (GET and POST), managing the web application lifecycle, and dispatching requests to the appropriate internal handlers for processing.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pinterest/git-stacktrace/blob/master/git_stacktrace/server.py#L1-L1" target="_blank" rel="noopener noreferrer">`git_stacktrace.server` (1:1)</a>
+
+
+
+
+
+### Web Request Handler
+
+This component is dedicated to parsing and validating input parameters received via HTTP requests (e.g., query string parameters for GET requests, JSON bodies for POST requests) for the web interface. After successful validation, it initiates calls to the Core API and Trace Parser to perform the stacktrace analysis.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pinterest/git-stacktrace/blob/master/git_stacktrace/server.py#L1-L1" target="_blank" rel="noopener noreferrer">`git_stacktrace.server` (1:1)</a>
+
+
+
+
+
+### Web Response Renderer
+
+This component is responsible for formatting and rendering the processed stacktrace analysis results into appropriate web-friendly formats, such as HTML pages or JSON responses, for the web interface. It leverages HTML templates for structured and consistent output.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pinterest/git-stacktrace/blob/master/git_stacktrace/server.py#L1-L1" target="_blank" rel="noopener noreferrer">`git_stacktrace.server` (1:1)</a>
+
+
+
+
+
+### Templates
+
+This component consists of HTML template files that define the structure and presentation of the web interface. These templates are utilized by the Web Response Renderer to dynamically construct web responses based on the processed data.
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+### Core API
+
+Core API component (details not provided in the input).
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+### Trace Parser
+
+Trace Parser component (details not provided in the input).
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/on_boarding.md
+++ b/.codeboarding/on_boarding.md
@@ -1,0 +1,179 @@
+```mermaid
+
+graph LR
+
+    User_Interface_UI_Layer["User Interface (UI) Layer"]
+
+    Core_Analysis_Engine["Core Analysis Engine"]
+
+    Git_Interaction_Module["Git Interaction Module"]
+
+    Traceback_Parsing_Module["Traceback Parsing Module"]
+
+    Result_Management_Module["Result Management Module"]
+
+    Testing_Suite["Testing Suite"]
+
+    User_Interface_UI_Layer -- "invokes" --> Core_Analysis_Engine
+
+    User_Interface_UI_Layer -- "consumes" --> Result_Management_Module
+
+    User_Interface_UI_Layer -- "uses" --> Traceback_Parsing_Module
+
+    Core_Analysis_Engine -- "orchestrates" --> Git_Interaction_Module
+
+    Core_Analysis_Engine -- "populates" --> Result_Management_Module
+
+    Testing_Suite -- "tests" --> User_Interface_UI_Layer
+
+    Testing_Suite -- "tests" --> Core_Analysis_Engine
+
+    Testing_Suite -- "tests" --> Git_Interaction_Module
+
+    Testing_Suite -- "tests" --> Traceback_Parsing_Module
+
+    Testing_Suite -- "tests" --> Result_Management_Module
+
+    click User_Interface_UI_Layer href "https://github.com/pinterest/git-stacktrace/blob/master/.codeboarding//User_Interface_UI_Layer.md" "Details"
+
+    click Core_Analysis_Engine href "https://github.com/pinterest/git-stacktrace/blob/master/.codeboarding//Core_Analysis_Engine.md" "Details"
+
+    click Git_Interaction_Module href "https://github.com/pinterest/git-stacktrace/blob/master/.codeboarding//Git_Interaction_Module.md" "Details"
+
+    click Traceback_Parsing_Module href "https://github.com/pinterest/git-stacktrace/blob/master/.codeboarding//Traceback_Parsing_Module.md" "Details"
+
+    click Result_Management_Module href "https://github.com/pinterest/git-stacktrace/blob/master/.codeboarding//Result_Management_Module.md" "Details"
+
+    click Testing_Suite href "https://github.com/pinterest/git-stacktrace/blob/master/.codeboarding//Testing_Suite.md" "Details"
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+One paragraph explaining the functionality which is represented by this graph. What the main flow is and what is its purpose.
+
+
+
+### User Interface (UI) Layer [[Expand]](./User_Interface_UI_Layer.md)
+
+Provides the primary entry points for users, handling command-line arguments or web requests and presenting the processed stacktrace analysis results.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pinterest/git-stacktrace/blob/master/git_stacktrace/cmd.py#L1-L1" target="_blank" rel="noopener noreferrer">`git_stacktrace.cmd` (1:1)</a>
+
+- <a href="https://github.com/pinterest/git-stacktrace/blob/master/git_stacktrace/server.py#L1-L1" target="_blank" rel="noopener noreferrer">`git_stacktrace.server` (1:1)</a>
+
+
+
+
+
+### Core Analysis Engine [[Expand]](./Core_Analysis_Engine.md)
+
+The central orchestrator for stacktrace lookup and analysis. It coordinates interactions with the Git Interaction and Traceback Parsing modules and populates the Result Management module.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pinterest/git-stacktrace/blob/master/git_stacktrace/api.py#L1-L1" target="_blank" rel="noopener noreferrer">`git_stacktrace.api` (1:1)</a>
+
+
+
+
+
+### Git Interaction Module [[Expand]](./Git_Interaction_Module.md)
+
+Encapsulates all interactions with the Git version control system, executing commands, parsing output, and retrieving commit, file, and line-level information.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pinterest/git-stacktrace/blob/master/git_stacktrace/git.py#L1-L1" target="_blank" rel="noopener noreferrer">`git_stacktrace.git` (1:1)</a>
+
+
+
+
+
+### Traceback Parsing Module [[Expand]](./Traceback_Parsing_Module.md)
+
+Responsible for parsing raw stacktrace text from various programming languages into a structured, programmatic representation.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pinterest/git-stacktrace/blob/master/git_stacktrace/parse_trace.py#L1-L1" target="_blank" rel="noopener noreferrer">`git_stacktrace.parse_trace` (1:1)</a>
+
+
+
+
+
+### Result Management Module [[Expand]](./Result_Management_Module.md)
+
+Defines and manages the data structures for representing the analysis results, including individual Result objects and Results collections, handling aggregation and sorting.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pinterest/git-stacktrace/blob/master/git_stacktrace/result.py#L1-L1" target="_blank" rel="noopener noreferrer">`git_stacktrace.result` (1:1)</a>
+
+
+
+
+
+### Testing Suite [[Expand]](./Testing_Suite.md)
+
+Provides the foundational framework and base classes for unit and integration tests, ensuring the reliability, correctness, and maintainability of the other functional modules.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `git_stacktrace.tests` (1:1)
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)


### PR DESCRIPTION
In this PR, I am adding a diagram visualizaiton for the git-stracktrace project.
I can see that you keep your `doc/source` as .rst files. I can integrate the diagrams within those if you like them (also we have a free github action to keep the whole thing up-to-date with new commits).

You can see how the diagrams in this change render here: https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/git-stacktrace/on_boarding.md

The goal of these documents is to help people get up to speed quickly with the git-stacktrace codebase. The diagrams are designed to give immediate overview of the codebase and allow you to dig deeper into each component of interest. The whole visualization is generated so it is easy to keep up-to-date. The generation is done via StaticAnalysis and LLMs.

Would love to connect and discuss if this is something interesting to pinterest, and how do you keep docs up-to-date so that people can get up-to-speed to different projects in their worklife!

Any feedback is more than welcome!

Full disclosure: we're trying to turn this into a startup, but we're still in a very early stage and figuring out what will actually be useful for people.